### PR TITLE
Release 0.0.25-alpha 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
 - Intenral change description x
   ([PR #123456](https://github.com/hmcts/hmcts-frontend/pull/123456))
 
+## 0.0.25-alpha
+
+🆕 New features:
+
+- The red warning banner now uses standard red colour instead of ‘bright-red’
+- The Identity Bar now takes multiple menus which accomodates the ability to have some primary actions and other actions tucked inside a toggle menu.
+- Now using latest GOV.UK Frontend v2.5.0
+
 ## 0.0.24-alpha
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/frontend",
   "description": "HMCTS Frontend contains the code you need to start building a user interface for HMCTS.",
-  "version": "0.0.24-alpha",
+  "version": "0.0.25-alpha",
   "main": "all.js",
   "sass": "all.scss",
   "engines": {


### PR DESCRIPTION
## 0.0.25-alpha

🆕 New features:

- The red warning banner now uses standard red colour instead of ‘bright-red’
- The Identity Bar now takes multiple menus which accomodates the ability to have some primary actions and other actions tucked inside a toggle menu.
- Now using latest GOV.UK Frontend v2.5.0