### PR TITLE
Release 0.0.26-alpha 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
 - Intenral change description x
   ([PR #123456](https://github.com/hmcts/hmcts-frontend/pull/123456))
 
+## 0.0.26-alpha
+
+🔧 Fixes:
+
+- Menu items that are links were inheriting styles from the base link style.
+- An open menu stayed open even if the user clicks somewhere else on the page.
+
 ## 0.0.25-alpha
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/frontend",
   "description": "HMCTS Frontend contains the code you need to start building a user interface for HMCTS.",
-  "version": "0.0.25-alpha",
+  "version": "0.0.26-alpha",
   "main": "all.js",
   "sass": "all.scss",
   "engines": {


### PR DESCRIPTION
🔧 Fixes:

- Menu items that are links were inheriting styles from the base link style.
- An open menu stayed open even if the user clicks somewhere else on the page.