### PR TITLE
style: set border-color of success and warning banners for IE11

### DIFF
--- a/src/components/banner/_banner.scss
+++ b/src/components/banner/_banner.scss
@@ -49,12 +49,12 @@
    ========================================================================== */
 
 .hmcts-banner--success {
-  border-color: inherit;
+  border-color: govuk-colour("green");
   color: govuk-colour("green");
 }
 
 
 .hmcts-banner--warning {
-  border-color: inherit;
+  border-color: govuk-colour("red");
   color: govuk-colour("red");
 }


### PR DESCRIPTION
### Change description ###

Previously `hmcts-banner--success` and `hmcts-banner--warning` had `border-color: inherit`, but on IE11, the borders are black. This PR explicitly sets the `border-color` property instead.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
