### PR TITLE
Release 0.0.33-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@
 - Intenral change description x
   ([PR #123456](https://github.com/hmcts/hmcts-frontend/pull/123456))
 
+## 0.0.33-alpha
+
+💥 Breaking changes:
+
+- Import path to macro updated to reflect the agreed convention
+  ([Issue #72](https://github.com/hmcts/frontend/issues/72))
+- Changed default SASS path to assets to `hmcts-assets` from `assets` so there's no chance of a clash with assets from GOV.UK Frontend, especially when using the extensions in the GOV.UK Prototype Kit.
+
+🔧 Fixes:
+
+- Internet Explorer 11 borders missing on banners. Thanks to [Matthew Burstein](https://github.com/MatthewBurstein)
+  ([PR #69](https://github.com/hmcts/frontend/pull/69))
+- Identity Bar simplified and pulls through menu classes. Thanks to [Ed Horsford](https://github.com/edwardhorsford)
+  ([Issue #68](https://github.com/hmcts/frontend/issues/68))
+
 ## 0.0.32-alpha
 
 🆕 New features:

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/frontend",
   "description": "HMCTS Frontend contains the code you need to start building a user interface for HMCTS.",
-  "version": "0.0.32-alpha",
+  "version": "0.0.33-alpha",
   "main": "all.js",
   "sass": "all.scss",
   "engines": {


### PR DESCRIPTION
💥 Breaking changes:

- Import path to macro updated to reflect the agreed convention
  ([Issue #72](https://github.com/hmcts/frontend/issues/72))
- Changed default SASS path to assets to `hmcts-assets` from `assets` so there's no chance of a clash with assets from GOV.UK Frontend, especially when using the extensions in the GOV.UK Prototype Kit.

🔧 Fixes:

- Internet Explorer 11 borders missing on banners. Thanks to [Matthew Burstein](https://github.com/MatthewBurstein)
  ([PR #69](https://github.com/hmcts/frontend/pull/69))
- Identity Bar simplified and pulls through menu classes. Thanks to [Ed Horsford](https://github.com/edwardhorsford)
  ([Issue #68](https://github.com/hmcts/frontend/issues/68))