### PR TITLE
Fix calls to govuk-colour

### DIFF
--- a/package/components/hmcts-header/_header.scss
+++ b/package/components/hmcts-header/_header.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .hmcts-header {
-  background-color: govuk-colour(black);
+  background-color: govuk-colour("black");
   padding-top: govuk-spacing(2);
 }
 
@@ -38,7 +38,7 @@
 .hmcts-header__link {
   @include govuk-font($size: 24, $weight: bold);
   border-bottom: 1px solid transparent;
-  color: govuk-colour(white);
+  color: govuk-colour("white");
   display: inline-block;
   text-decoration: none;
   line-height: 25px; // Override due to alignment issue in Chrome
@@ -50,16 +50,16 @@
   &:visited,
   &:hover,
   &:active {
-    color: govuk-colour(white);
+    color: govuk-colour("white");
   }
 
   &:hover {
-    border-color: govuk-colour(white);
+    border-color: govuk-colour("white");
   }
 
   &:focus {
     border-color: transparent;
-    color: govuk-colour(black);
+    color: govuk-colour("black");
   }
 
 }
@@ -67,7 +67,7 @@
 
 // Navigation
 .hmcts-header__navigation {
-  color: govuk-colour(white);
+  color: govuk-colour("white");
   margin-top: govuk-spacing(1)-2px;
 }
 
@@ -105,7 +105,7 @@
   }
 
   &:focus {
-    color: govuk-colour(black);
+    color: govuk-colour("black");
   }
 
 }

--- a/package/components/hmcts-sub-navigation/_sub-navigation.scss
+++ b/package/components/hmcts-sub-navigation/_sub-navigation.scss
@@ -66,7 +66,7 @@
 
 
 .hmcts-sub-navigation__link[aria-current="page"] {
-  color: govuk-colour(black);
+  color: govuk-colour("black");
   position: relative;
   text-decoration: none;
 

--- a/src/components/hmcts-header/_header.scss
+++ b/src/components/hmcts-header/_header.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .hmcts-header {
-  background-color: govuk-colour(black);
+  background-color: govuk-colour("black");
   padding-top: govuk-spacing(2);
 }
 
@@ -38,7 +38,7 @@
 .hmcts-header__link {
   @include govuk-font($size: 24, $weight: bold);
   border-bottom: 1px solid transparent;
-  color: govuk-colour(white);
+  color: govuk-colour("white");
   display: inline-block;
   text-decoration: none;
   line-height: 25px; // Override due to alignment issue in Chrome
@@ -50,16 +50,16 @@
   &:visited,
   &:hover,
   &:active {
-    color: govuk-colour(white);
+    color: govuk-colour("white");
   }
 
   &:hover {
-    border-color: govuk-colour(white);
+    border-color: govuk-colour("white");
   }
 
   &:focus {
     border-color: transparent;
-    color: govuk-colour(black);
+    color: govuk-colour("black");
   }
 
 }
@@ -67,7 +67,7 @@
 
 // Navigation
 .hmcts-header__navigation {
-  color: govuk-colour(white);
+  color: govuk-colour("white");
   margin-top: govuk-spacing(1)-2px;
 }
 
@@ -105,7 +105,7 @@
   }
 
   &:focus {
-    color: govuk-colour(black);
+    color: govuk-colour("black");
   }
 
 }

--- a/src/components/hmcts-sub-navigation/_sub-navigation.scss
+++ b/src/components/hmcts-sub-navigation/_sub-navigation.scss
@@ -66,7 +66,7 @@
 
 
 .hmcts-sub-navigation__link[aria-current="page"] {
-  color: govuk-colour(black);
+  color: govuk-colour("black");
   position: relative;
   text-decoration: none;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Calls to govuk-colour can fail during the build process of Angular projects when colournames are not properly quoted.
This PR adds quotes to all colournames that were missing quotes to fix these blocking build issues.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
